### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/website/src/scripts/pages/index.ts
+++ b/website/src/scripts/pages/index.ts
@@ -102,7 +102,7 @@ export async function initHomepage(): Promise<void> {
               <span class="search-result-type">${getResourceIcon(item.type)}</span>
               <div>
                 <div class="search-result-title">${search.highlight(item.title, query)}</div>
-                <div class="search-result-description">${truncate(item.description, 60)}</div>
+                <div class="search-result-description">${escapeHtml(truncate(item.description, 60))}</div>
               </div>
             </button>
           `).join('');


### PR DESCRIPTION
Potential fix for [https://github.com/Altinn/kihub/security/code-scanning/4](https://github.com/Altinn/kihub/security/code-scanning/4)

General fix: never inject untrusted text into `innerHTML` unless it is contextually escaped first (or inserted via `textContent`/DOM APIs).  
Best minimal fix here: keep existing rendering approach, but explicitly escape `item.description` before interpolation.

In `website/src/scripts/pages/index.ts`, in the `results.map(item => ...)` template, update line containing:
```ts
<div class="search-result-description">${truncate(item.description, 60)}</div>
```
to:
```ts
<div class="search-result-description">${escapeHtml(truncate(item.description, 60))}</div>
```

No new imports are needed because `escapeHtml` is already imported in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
