### PR TITLE
Redesign tools page as unified resource list and toggle role-cards on homepage

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -23,6 +23,8 @@ const audienceRoles = [
   { label: 'Sikkerhet', tone: 'red', href: `${base}tools/` },
   { label: 'Saksbehandler', tone: 'pink', href: `${base}tools/` },
 ];
+// Set to true when role-specific guides are ready
+const SHOW_ROLES_SECTION = false;
 ---
 
 <StarlightPage
@@ -122,29 +124,31 @@ const audienceRoles = [
       </div>
     </section>
 
-    <section class="v2-roles-section" aria-labelledby="roles-heading">
-      <h2 id="roles-heading">Kom raskt i gang</h2>
-      <ul class="v2-roles-grid" aria-label="Roller">
-        {audienceRoles.map((role) => (
-          <li>
-            <a
-              href={role.href}
-              class="v2-role-card ds-focus"
-              data-tone={role.tone}
-              aria-label={`Kom raskt i gang som ${role.label}`}
-            >
-              <h3>
-                {role.label}<span class="v2-card-arrow v2-role-arrow" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" focusable="false">
-                    <path d="M5 12h14M13 6l6 6-6 6"></path>
-                  </svg>
-                </span>
-              </h3>
-            </a>
-          </li>
-        ))}
-      </ul>
-    </section>
+    {SHOW_ROLES_SECTION && (
+      <section class="v2-roles-section" aria-labelledby="roles-heading">
+        <h2 id="roles-heading">Kom raskt i gang</h2>
+        <ul class="v2-roles-grid" aria-label="Roller">
+          {audienceRoles.map((role) => (
+            <li>
+              <a
+                href={role.href}
+                class="v2-role-card ds-focus"
+                data-tone={role.tone}
+                aria-label={`Kom raskt i gang som ${role.label}`}
+              >
+                <h3>
+                  {role.label}<span class="v2-card-arrow v2-role-arrow" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" focusable="false">
+                      <path d="M5 12h14M13 6l6 6-6 6"></path>
+                    </svg>
+                  </span>
+                </h3>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    )}
 
     {
       latestNews.length > 0 && (

--- a/website/src/pages/tools.astro
+++ b/website/src/pages/tools.astro
@@ -1,243 +1,268 @@
 ---
 import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 import toolsData from '../../public/data/tools.json';
-import ContributeCTA from "../components/ContributeCTA.astro";
-import EmbeddedPageData from "../components/EmbeddedPageData.astro";
+import agentsData from '../../public/data/agents.json';
+import instructionsData from '../../public/data/instructions.json';
 import PageHeader from "../components/PageHeader.astro";
-import { renderToolsHtml } from "../scripts/pages/tools-render";
 
-const initialItems = toolsData.items.map((item) => ({
-  ...item,
-  title: item.name,
+const base = import.meta.env.BASE_URL;
+
+interface Resource {
+  id: string;
+  title: string;
+  description: string;
+  type: string;
+  color: 'accent' | 'warning' | 'success';
+  category?: string;
+  primaryHref?: string;
+  primaryLabel?: string;
+}
+
+function pickLink(links: Record<string, string>): string | undefined {
+  return links?.vscode ?? links?.github ?? links?.documentation ?? links?.release;
+}
+
+function pickLabel(links: Record<string, string>): string {
+  if (links?.vscode) return 'Åpne i VS Code';
+  if (links?.github) return 'GitHub';
+  if (links?.documentation) return 'Dokumentasjon';
+  if (links?.release) return 'Last ned';
+  return 'Åpne';
+}
+
+const tools: Resource[] = (toolsData.items as any[]).map((t) => ({
+  id: t.id,
+  title: t.name,
+  description: t.description,
+  type: 'Verktøy',
+  color: 'accent' as const,
+  category: t.category ?? undefined,
+  primaryHref: pickLink(t.links ?? {}),
+  primaryLabel: pickLabel(t.links ?? {}),
 }));
+
+const agents: Resource[] = (agentsData.items as any[]).map((a) => ({
+  id: a.id,
+  title: a.title,
+  description: a.description,
+  type: 'Agent',
+  color: 'warning' as const,
+  primaryHref: `${base}agents/`,
+  primaryLabel: 'Se agenter',
+}));
+
+const instructions: Resource[] = (instructionsData.items as any[]).map((i) => ({
+  id: i.id,
+  title: i.title,
+  description: i.description,
+  type: 'Instruksjon',
+  color: 'success' as const,
+  primaryHref: `${base}instructions/`,
+  primaryLabel: 'Se instruksjoner',
+}));
+
+const allResources: Resource[] = [...tools, ...agents, ...instructions];
 ---
 
-<StarlightPage frontmatter={{ title: 'Tools', description: 'Apps, MCP servers, and developer tools for GitHub Copilot', template: 'splash', prev: false, next: false, editUrl: false }}>
+<StarlightPage frontmatter={{ title: 'Ressurser', description: 'Godkjente verktøy, agenter og instruksjoner fra KITT-teamet i BOD', template: 'splash', prev: false, next: false, editUrl: false }}>
   <div id="main-content">
-    <PageHeader title="🔧 Tools" description="Apps, MCP servers, and developer tools for GitHub Copilot" />
+    <PageHeader
+      title="Ressurser"
+      description="Godkjente verktøy, agenter og instruksjoner for trygg og effektiv bruk av KI i Digdir."
+    />
 
     <div class="page-content">
       <div class="container">
-        <div class="search-section">
-          <div class="search-bar ds-search">
-            <label for="search-input" class="sr-only">Search tools</label>
-            <input
-              type="search"
-              id="search-input"
-              placeholder="Search tools..."
-              class="ds-input search-input"
-            />
-          </div>
-          <div class="filters">
-            <label for="filter-category" class="sr-only">Filter by category</label>
-            <select id="filter-category" class="ds-input filter-select" aria-label="Filter by category">
-              <option value="">All Categories</option>
-              {toolsData.filters.categories.map((category) => (
-                <option value={category}>{category}</option>
-              ))}
-            </select>
-            <button id="clear-filters" class="ds-button" data-variant="secondary" data-size="sm"
-              >Clear</button
-            >
-          </div>
-          <div id="results-count" class="results-count" aria-live="polite">{initialItems.length} of {initialItems.length} tools</div>
-        </div>
 
-        <div id="tools-list" role="list" set:html={renderToolsHtml(initialItems)}></div>
-
-        <div class="coming-soon">
-          <h2>More Tools Coming Soon</h2>
-          <p>
-            We're working on additional tools to enhance your GitHub Copilot
-            experience. Check back soon!
-          </p>
-        </div>
-        <ContributeCTA resourceType="tools" />
+        <ul class="res-grid" role="list" aria-label="Ressurser">
+          {allResources.map((resource) => (
+            <li class="res-card" role="listitem">
+              <div class="res-card-meta">
+                <span class="ds-tag res-type-badge" data-color={resource.color} data-size="sm">
+                  {resource.type}
+                </span>
+                {resource.category && (
+                  <span class="res-category">{resource.category}</span>
+                )}
+              </div>
+              <h2 class="res-title">{resource.title}</h2>
+              <p class="res-description">{resource.description}</p>
+              {resource.primaryHref && (
+                <div class="res-actions">
+                  <a
+                    href={resource.primaryHref}
+                    class="ds-button"
+                    data-variant="secondary"
+                    data-size="sm"
+                    target={resource.primaryHref.startsWith('http') ? '_blank' : undefined}
+                    rel={resource.primaryHref.startsWith('http') ? 'noopener noreferrer' : undefined}
+                  >
+                    {resource.primaryLabel}
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="14" height="14">
+                      <path d="M5 12h14M13 6l6 6-6 6"></path>
+                    </svg>
+                  </a>
+                </div>
+              )}
+            </li>
+          ))}
+          <li class="res-card res-card--cta" role="listitem">
+            <div class="cta-content">
+              <h2 class="cta-title">Finner du ikke det du leter etter?</h2>
+              <p class="cta-desc">Denne samlingen er fellesskapsdrevet. Del dine egne ressurser for å hjelpe andre.</p>
+            </div>
+            <div class="cta-actions">
+              <a href="https://github.com/Altinn/kihub/blob/main/CONTRIBUTING.md" class="ds-button" target="_blank" rel="noopener noreferrer">
+                Bidra med en ressurs
+                <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
+                  <path d="M7.75 2a.75.75 0 0 1 .75.75V7h4.25a.75.75 0 0 1 0 1.5H8.5v4.25a.75.75 0 0 1-1.5 0V8.5H2.75a.75.75 0 0 1 0-1.5H7V2.75A.75.75 0 0 1 7.75 2Z"/>
+                </svg>
+              </a>
+              <a href="https://github.com/Altinn/kihub/issues/new" class="ds-button" data-variant="secondary" target="_blank" rel="noopener noreferrer">
+                Be om en ressurs
+              </a>
+            </div>
+          </li>
+        </ul>
       </div>
     </div>
   </div>
 
-  <EmbeddedPageData filename="tools.json" data={toolsData} />
-
   <style is:global>
-    .search-section {
-      margin-bottom: var(--ds-size-6);
+    #main-content {
+      --kihub-serif-font: "PT Serif", Georgia, "Times New Roman", serif;
+      font-family: var(--kihub-serif-font);
     }
 
-    .search-bar {
-      margin-bottom: var(--ds-size-4);
+    #main-content :where(a, button, p, h1, h2, h3, span) {
+      font-family: inherit;
     }
 
-    .filters {
+    .res-grid {
+      list-style: none;
+      padding: 0;
+      margin: 0 0 var(--ds-size-8);
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: var(--ds-size-5);
+    }
+
+    .res-card {
       display: flex;
-      gap: var(--ds-size-3);
-      flex-wrap: wrap;
-      align-items: center;
-    }
-
-    .filter-select {
-      min-width: 180px;
-    }
-
-    .results-count {
-      margin-top: var(--ds-size-3);
-    }
-
-    .empty-state {
-      text-align: center;
-    }
-
-    .tool-card {
-      margin-bottom: var(--ds-size-6);
-    }
-
-    .tool-header {
-      display: flex;
-      align-items: center;
-      gap: var(--ds-size-3);
-      margin-bottom: var(--ds-size-4);
-      flex-wrap: wrap;
-    }
-
-    .tool-header h2 {
-      margin: 0;
-      font-size: var(--ds-heading-xs-font-size);
-      color: var(--ds-color-neutral-text-default);
-    }
-
-    .tool-badges {
-      display: flex;
-      gap: var(--ds-size-2);
-      flex-wrap: wrap;
-    }
-
-    .tool-badge {
-      white-space: nowrap;
-    }
-
-    .tool-description {
-      color: var(--ds-color-neutral-text-subtle);
-      font-size: var(--ds-body-md-font-size);
-      line-height: var(--ds-body-long-md-line-height);
-      margin-bottom: var(--ds-size-6);
-    }
-
-    .tool-section {
-      margin-top: var(--ds-size-6);
-    }
-
-    .tool-section h3 {
-      margin-bottom: var(--ds-size-3);
-      font-size: var(--ds-heading-2xs-font-size);
-      font-weight: var(--ds-font-weight-medium);
-      color: var(--ds-color-neutral-text-default);
-    }
-
-    .tool-section ul {
-      margin: 0;
-      padding-left: var(--ds-size-6);
-      color: var(--ds-color-neutral-text-subtle);
-    }
-
-    .tool-section li {
-      margin-bottom: var(--ds-size-2);
-    }
-
-    .tool-note {
-      color: var(--ds-color-neutral-text-subtle);
-      margin: 0;
-      line-height: 1.6;
-    }
-
-    .tool-tags {
-      display: flex;
-      flex-wrap: wrap;
-      gap: var(--ds-size-2);
-      margin-top: var(--ds-size-5);
-    }
-
-    .tool-config {
-      margin-top: var(--ds-size-6);
-    }
-
-    .tool-config h3 {
-      margin-bottom: var(--ds-size-3);
-      font-size: var(--ds-heading-2xs-font-size);
-      font-weight: var(--ds-font-weight-medium);
-      color: var(--ds-color-neutral-text-default);
-    }
-
-    .tool-config-wrapper {
-      position: relative;
-      max-width: 100%;
-      overflow: hidden;
-    }
-
-    .tool-config pre {
-      background-color: var(--ds-color-neutral-background-tinted);
-      border: var(--ds-border-width-default) solid var(--ds-color-neutral-border-subtle);
-      border-radius: var(--ds-border-radius-default);
-      padding: var(--ds-size-4);
-      overflow-x: auto;
-      margin: 0;
-    }
-
-    .tool-config code {
-      display: block;
-      font-family: var(--font-mono);
-      font-size: var(--ds-body-sm-font-size);
-      color: var(--ds-color-neutral-text-default);
-      white-space: pre-wrap;
-      overflow-wrap: anywhere;
-      word-break: break-word;
-    }
-
-    .tool-actions {
-      margin-top: var(--ds-size-6);
-      padding-top: var(--ds-size-6);
-      border-top: var(--ds-border-width-default) solid var(--ds-color-neutral-border-subtle);
-      display: flex;
-      flex-wrap: wrap;
-      gap: var(--ds-size-3);
-    }
-
-    .coming-soon {
-      text-align: center;
-      padding: var(--ds-size-10);
-      background-color: var(--ds-color-neutral-surface-default);
-      border: var(--ds-border-width-default) dashed var(--ds-color-neutral-border-subtle);
+      flex-direction: column;
+      padding: var(--ds-size-6);
       border-radius: var(--ds-border-radius-lg);
+      background: var(--ds-color-neutral-background-default, var(--color-bg));
+      border: none;
+      box-shadow: none;
     }
 
-    .coming-soon h2 {
+    .res-card-meta {
+      display: flex;
+      align-items: center;
+      gap: var(--ds-size-2);
+      margin-bottom: var(--ds-size-3);
+      flex-wrap: wrap;
+    }
+
+    .res-category {
+      font-size: var(--ds-body-xs-font-size);
       color: var(--ds-color-neutral-text-subtle);
-      margin-bottom: var(--ds-size-2);
     }
 
-    .coming-soon p {
+    .res-title {
+      font-size: var(--ds-heading-xs-font-size);
+      font-weight: var(--ds-font-weight-semibold);
+      color: var(--ds-color-neutral-text-default);
+      margin: 0 0 var(--ds-size-3);
+      line-height: var(--ds-line-height-sm);
+    }
+
+    .res-description {
+      font-size: var(--ds-body-sm-font-size);
       color: var(--ds-color-neutral-text-subtle);
+      line-height: var(--ds-line-height-md);
+      margin: 0 0 var(--ds-size-5);
+      flex: 1;
+      overflow: hidden;
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
     }
 
-    .copy-config-btn {
-      margin-top: var(--ds-size-3);
+    .res-actions {
+      margin-top: auto;
     }
 
-    .copy-config-btn.copied {
-      background-color: var(--ds-color-success-base-default);
-      color: var(--ds-color-success-base-contrast-default);
-      border-color: var(--ds-color-success-base-default);
+    .res-actions .ds-button {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--ds-size-2);
+      width: 100%;
+      justify-content: center;
     }
 
-    /* Search highlight */
-    .search-highlight {
-      background-color: var(--ds-color-warning-surface-tinted);
-      color: var(--ds-color-warning-text-default);
-      padding: 0 2px;
-      border-radius: var(--ds-border-radius-sm);
+    .res-card--cta {
+      grid-column: 1 / -1;
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--ds-size-6);
+      border: 1px dashed var(--ds-color-neutral-border-subtle);
+      background: transparent;
+      padding: var(--ds-size-6) var(--ds-size-8);
+    }
+
+    .res-card--cta .cta-content {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .res-card--cta .cta-title {
+      font-size: var(--ds-heading-xs-font-size);
+      font-weight: var(--ds-font-weight-semibold);
+      color: var(--ds-color-neutral-text-default);
+      margin: 0 0 var(--ds-size-2);
+    }
+
+    .res-card--cta .cta-desc {
+      font-size: var(--ds-body-sm-font-size);
+      color: var(--ds-color-neutral-text-subtle);
+      margin: 0;
+      line-height: var(--ds-line-height-md);
+    }
+
+    .res-card--cta .cta-actions {
+      display: flex;
+      gap: var(--ds-size-3);
+      flex-shrink: 0;
+    }
+
+    @media (max-width: 900px) {
+      .res-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (max-width: 560px) {
+      .res-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .res-card--cta {
+        flex-direction: column;
+        align-items: flex-start;
+        padding: var(--ds-size-6);
+      }
+
+      .res-card--cta .cta-actions {
+        flex-direction: column;
+        width: 100%;
+      }
+
+      .res-card--cta .cta-actions .ds-button {
+        justify-content: center;
+      }
     }
   </style>
-
-  <script>
-    import '../scripts/pages/tools';
-  </script>
 </StarlightPage>


### PR DESCRIPTION
## Description
This pull request implements the changes planned in **Issue #82**:

1. **Unified Resource List on `/tools/` page (`website/src/pages/tools.astro`)**:
   - Imported and combined three distinct data sources (`tools.json`, `agents.json`, and `instructions.json` from `website/public/data/`) into a single flat array.
   - Normalized all resource items to have standard structure (`title`, `description`, `type`, `color`, and access properties).
   - Mapped semantic color tags:
     - Tools (Verktøy) -> `accent`
     - Agents (Agent) -> `warning`
     - Instructions (Instruksjon) -> `success`
   - Removed the filter dropdown, search input, and "More Tools Coming Soon" section, leaving a clean, simple flat list layout.
   - Restyled the layout to a clean grid containing a Call-to-Action for contributing or requesting new resources.
   - Updated the frontmatter title/description metadata to "Ressurser".

2. **Hiding Homepage Role-Cards (`website/src/pages/index.astro`)**:
   - Added a `SHOW_ROLES_SECTION = false` toggle.
   - Wrapped the "Kom raskt i gang" section in a conditional block to hide it until specific content for those roles exists.

Resolves #82
