### PR TITLE
Reorder primary navigation and rename Læringssenter to KI Læring

### DIFF
--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -13,8 +13,8 @@ const currentPath = normalizePath(Astro.url.pathname);
 const navItems = [
   { label: 'Hjem', href: '/' },
   { label: 'Verktøy', href: '/tools/' },
+  { label: 'KI Læring', href: '/learning-hub/' },
   { label: 'Prosjekter', href: '/prosjekter/' },
-  { label: 'Læringssenter', href: '/learning-hub/' },
   { label: 'Nyheter', href: '/nyheter/' },
   { label: 'Om KITT', href: '/om-kitt/' },
 ];

--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -12,10 +12,10 @@ const normalizePath = (path: string) => {
 const currentPath = normalizePath(Astro.url.pathname);
 const navItems = [
   { label: 'Hjem', href: '/' },
-  { label: 'Verktøy', href: '/tools/' },
   { label: 'KI Læring', href: '/learning-hub/' },
   { label: 'Prosjekter', href: '/prosjekter/' },
   { label: 'Nyheter', href: '/nyheter/' },
+  { label: 'Verktøy', href: '/tools/' },
   { label: 'Om KITT', href: '/om-kitt/' },
 ];
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -52,8 +52,8 @@ const SHOW_ROLES_SECTION = false;
           Vi hjelper deg og ditt team i gang med verktøy og veiledning for en trygg og innovativ bruk av KI i offentlig sektor.
         </p>
         <div class="v2-hero-actions" aria-label="Hurtigvalg">
-          <a class="ds-button v2-primary-action" href={`${base}tools/`}>
-            Kom i gang
+          <a class="ds-button v2-primary-action" href={`${base}learning-hub/`}>
+            KI Læring
             <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
               <path d="M5 12h14M13 6l6 6-6 6"></path>
             </svg>


### PR DESCRIPTION
## Summary

Closes #94

Reorders the primary navigation to prioritize learning/onboarding content and renames "Læringssenter" to **"KI Læring"** for a shorter, on-brand label.

## Changes

### Navigation reorder (`Header.astro`)

The nav items were reordered to place educational resources in a more prominent position, immediately after Hjem:

| Position | Before | After |
|---|---|---|
| 1 | Hjem | Hjem |
| 2 | ~~Verktøy~~ | **KI Læring** |
| 3 | Prosjekter | Prosjekter |
| 4 | ~~Læringssenter~~ | Nyheter |
| 5 | Nyheter | Verktøy |
| 6 | Om KITT | Om KITT |

**Key decisions:**
- **KI Læring moved to position 2** — learning content is the logical starting point for new employees, agile coaches, and POs arriving at KI Hub. It should not be buried behind project status content.
- **Verktøy moved after Nyheter** — tools are actionable resources but serve returning users more than newcomers; news and projects provide better context first.
- **Label renamed** from "Læringssenter" → "KI Læring" — shorter, on-brand, and easier to scan in the nav bar.

### Homepage hero CTA (`index.astro`)

- Updated the primary hero call-to-action button to link to `/learning-hub/` instead of `/tools/`
- Button label changed from "Kom i gang" → **"KI Læring"** to align with the new nav label and reinforce the learning-first onboarding flow

### What did NOT change
- The underlying route (`/learning-hub/`) remains the same
- No page content was modified
- Mobile hamburger menu inherits the same order from the `navItems` array — no separate change needed

## Acceptance Criteria Checklist

- [x] Primary nav order updated: Hjem → KI Læring → Prosjekter → Nyheter → Verktøy → Om KITT
- [x] Nav label reads "KI Læring" (not "Læringssenter")
- [x] Mobile hamburger menu reflects the same order and label (shared `navItems` array)
- [x] Homepage hero CTA updated to point to KI Læring
- [x] No broken links or layout regressions